### PR TITLE
Dev changes appear stable with 1.5 flash instead of exp

### DIFF
--- a/app/(auth)/sign-in/[[...sign-in]]/page.js
+++ b/app/(auth)/sign-in/[[...sign-in]]/page.js
@@ -12,7 +12,8 @@ export default function SignInPage() {
         <section className="relative flex h-32 items-end bg-gray-900 lg:col-span-5 lg:h-full xl:col-span-6">
           <img
             alt=""
-            src="https://images.pexels.com/photos/1049317/pexels-photo-1049317.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1"
+            src="https://images.unsplash.com/photo-1444312645910-ffa973656eba?q=80&w=1887&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+            // src="https://images.pexels.com/photos/1049317/pexels-photo-1049317.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1"
             className="absolute inset-0 h-full w-full object-cover opacity-80"
           />
 

--- a/app/(auth)/sign-up/[[...sign-up]]/page.js
+++ b/app/(auth)/sign-up/[[...sign-up]]/page.js
@@ -12,7 +12,8 @@ export default function SignUpPage() {
         <section className="relative flex h-32 items-end bg-gray-900 lg:col-span-5 lg:h-full xl:col-span-6">
           <img
             alt=""
-            src="https://images.pexels.com/photos/1049317/pexels-photo-1049317.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1"
+            src="https://images.unsplash.com/photo-1444312645910-ffa973656eba?q=80&w=1887&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+            // src="https://images.pexels.com/photos/1049317/pexels-photo-1049317.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1"
             className="absolute inset-0 h-full w-full object-cover opacity-80"
           />
 

--- a/app/api/chat/route.js
+++ b/app/api/chat/route.js
@@ -22,7 +22,7 @@ export async function POST(req) {
   const data = await req.json();
   const completion = await openai.chat.completions.create({
     messages: [{ role: "system", content: systemPrompt }, ...data],
-    model: "google/gemini-flash-1.5-exp",
+    model: "google/gemini-flash-1.5",
   });
 
   const responseContent = completion.choices[0].message.content;

--- a/app/chat/page.js
+++ b/app/chat/page.js
@@ -85,14 +85,6 @@ const Chatbox = () => {
   const messagesEndRef = useRef(null);
   const chatContainerRef = useRef(null);
 
-  //   const scrollToBottom = () => {
-  //     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  //   };
-
-  //   useEffect(() => {
-  //     scrollToBottom();
-  //   }, [messages]);
-
   const scrollToBottom = () => {
     chatContainerRef.current?.scrollTo({
       top: chatContainerRef.current.scrollHeight,

--- a/app/roadmap/page.js
+++ b/app/roadmap/page.js
@@ -174,6 +174,7 @@ export default function HeroSection() {
             </p>
             <ul>
               <li>Mutlilingual support</li>
+              <li>Providing helplines for suicidal thoughts and distress</li>
               <li>Persistance by using a realtime DB</li>
               <li>RAG to help student learn material better</li>
             </ul>

--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,12 @@ module.exports = {
         port: "",
         pathname: "/**",
       },
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com",
+        port: "",
+        pathname: "/**",
+      },
     ],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@clerk/nextjs": "^5.6.4",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
+        "@google/generative-ai": "^0.20.0",
         "@mui/material": "^6.1.1",
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/themes": "^3.1.4",
@@ -483,6 +484,14 @@
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
       "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.20.0.tgz",
+      "integrity": "sha512-uJQNDr1sihvBJ9w8B0ESpNdX9aEueAMXgwnTuhTo+LnI7DD0M1KHnOWzxb2l6cM1rRHzvkdgJNNfeybcqg7uVg==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@clerk/nextjs": "^5.6.4",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
+    "@google/generative-ai": "^0.20.0",
     "@mui/material": "^6.1.1",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/themes": "^3.1.4",


### PR DESCRIPTION
Tested the gemini client side API but sticking with Open AI client side while switching from gemini 1.5 flash exp to gemini 1.5 flash stable. Image has been changed to match the theme and roadmap expanded. Unsplash has been added to the list of trusted domains for nextjs images.